### PR TITLE
Added support for Windows Named Semaphores Permissions.

### DIFF
--- a/src/Interprocess.sln
+++ b/src/Interprocess.sln
@@ -23,6 +23,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{A178B233
 		..\.github\workflows\publish.yml = ..\.github\workflows\publish.yml
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{0A028575-B2D6-41AE-9201-4B14BD5725DE}"
+	ProjectSection(SolutionItems) = preProject
+		NugetPackages\Cloudtoid.Interprocess.1.0.156.nupkg = NugetPackages\Cloudtoid.Interprocess.1.0.156.nupkg
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/Interprocess/Interprocess.csproj
+++ b/src/Interprocess/Interprocess.csproj
@@ -22,5 +22,8 @@
     <VersionSuffix Condition=" '$(VersionSuffix)'=='' ">0</VersionSuffix>
     <Version>1.0.$(VersionSuffix)</Version>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Threading.AccessControl" Version="5.0.0" />
+  </ItemGroup>
 
 </Project>

--- a/src/Interprocess/Interprocess.csproj
+++ b/src/Interprocess/Interprocess.csproj
@@ -20,7 +20,9 @@
     <PackageTags>interprocess;interprocess-communication;ipc;shared-memory-communication;shared-memory-queue;shared-memory;memory-mapped-file;queue;cross-process-communication;cross-process</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <VersionSuffix Condition=" '$(VersionSuffix)'=='' ">0</VersionSuffix>
-    <Version>1.0.$(VersionSuffix)</Version>
+    <Version>1.0.156</Version>
+    <AssemblyVersion>1.0.156.1</AssemblyVersion>
+    <FileVersion>1.0.156.1</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Threading.AccessControl" Version="5.0.0" />

--- a/src/Interprocess/Semaphore/Windows/SemaphoreWindows.cs
+++ b/src/Interprocess/Semaphore/Windows/SemaphoreWindows.cs
@@ -1,5 +1,14 @@
-﻿using SysSemaphore = System.Threading.Semaphore;
-
+﻿using AccessControlType = System.Security.AccessControl.AccessControlType;
+using Debug = System.Diagnostics.Debug;
+using OS = System.Runtime.InteropServices.OSPlatform;
+using RunTimeInfo = System.Runtime.InteropServices.RuntimeInformation;
+using SecurityIdentifier = System.Security.Principal.SecurityIdentifier;
+using SemaphoreAccessRule = System.Security.AccessControl.SemaphoreAccessRule;
+using SemaphoreRights = System.Security.AccessControl.SemaphoreRights;
+using SemaphoreSecurity = System.Security.AccessControl.SemaphoreSecurity;
+using SysSemaphore = System.Threading.Semaphore;
+using ThreadingAclExtensions = System.Threading.ThreadingAclExtensions;
+using WellKnownSidType = System.Security.Principal.WellKnownSidType;
 namespace Cloudtoid.Interprocess.Semaphore.Windows
 {
     // just a wrapper over the Windows named semaphore
@@ -10,7 +19,32 @@ namespace Cloudtoid.Interprocess.Semaphore.Windows
 
         internal SemaphoreWindows(string name)
         {
-            handle = new SysSemaphore(0, int.MaxValue, HandleNamePrefix + name);
+            /*
+             * handle = new SysSemaphore(0, int.MaxValue, HandleNamePrefix + name);
+             */
+            //2021-06-02 Fabian Ramirez - Adding code to handle permissions when accessing the semaphore from different windows accounts
+            string semaphorename = HandleNamePrefix + name;
+
+            handle = new SysSemaphore(0, int.MaxValue, semaphorename);
+            if (RunTimeInfo.IsOSPlatform(OS.Windows))
+            {
+                try
+                {
+                    SemaphoreSecurity semaphoreSecurity = new SemaphoreSecurity();
+                    var sid = new SecurityIdentifier(WellKnownSidType.WorldSid, null);
+                    semaphoreSecurity.AddAccessRule(new SemaphoreAccessRule(sid, SemaphoreRights.FullControl, AccessControlType.Allow));
+                    ThreadingAclExtensions.SetAccessControl(handle, semaphoreSecurity);
+                }
+                catch (System.Exception ex)
+                {
+                    Debug.WriteLine("Exception Setting Semaphore Security");
+                    Debug.WriteLine(ex.Message);
+                    if (ex.StackTrace != null)
+                        Debug.WriteLine(ex.StackTrace.ToString());
+                }
+            }
+
+            //2021-06-02 Fabian Ramirez - END
         }
 
         public void Dispose()


### PR DESCRIPTION
So processes runnnig under privileged accounts(i.e. LocalSystem) can share semaphores with
processes running under non privilieged accounts.
Added package System.Threading.AccessControl to fulfill the Semaphore.SetAccessControl method.